### PR TITLE
implement Cgroup namespace isolation:

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -30,13 +30,10 @@
 
 **System Requirements:**
 
-- **Operating System**: Linux (production) or macOS (development/testing)
-- **Go Version**: 1.23 or later
-- **Linux Requirements**:
-    - Kernel 4.5+ (for cgroups v2 support)
-    - Root access (for cgroup management and namespace isolation)
-    - systemd (recommended for service management)
-    - Support for `/sys/fs/cgroup` (cgroups v2)
+- **Kernel**: Linux 4.6+ (for cgroup namespace support)
+- **Cgroups**: cgroups v2 enabled and mounted at /sys/fs/cgroup
+- **Namespaces**: Cgroup namespace support in kernel
+- **Root Access**: Required for cgroup management and namespace operations
 
 ## 📖 Usage Examples
 

--- a/internal/jobinit/platform.go
+++ b/internal/jobinit/platform.go
@@ -7,14 +7,12 @@ type JobInitializer interface {
 	ExecuteJob(config *JobConfig) error
 }
 
-// JobConfig is shared across platforms (simplified for Option 3)
+// JobConfig is shared across platforms
 type JobConfig struct {
-	JobID             string
-	Command           string
-	Args              []string
-	CgroupPath        string
-	NetworkGroupID    string // Network group identifier
-	IsNewNetworkGroup bool   // Whether this is a new network group (for setup)
+	JobID      string
+	Command    string
+	Args       []string
+	CgroupPath string
 }
 
 // Run is the entry point that works on all platforms

--- a/internal/worker/jobworker/linux/process/cleanup.go
+++ b/internal/worker/jobworker/linux/process/cleanup.go
@@ -319,7 +319,7 @@ func (c *Cleaner) parseStringToInt(s string) (int, error) {
 	var result int
 	var err error
 
-	// Simple integer parsing to avoid external dependencies
+	// Integer parsing to avoid external dependencies
 	if len(s) == 0 {
 		return 0, fmt.Errorf("empty string")
 	}

--- a/internal/worker/jobworker/linux/process/launcher.go
+++ b/internal/worker/jobworker/linux/process/launcher.go
@@ -309,10 +309,11 @@ func (l *Launcher) CreateSysProcAttr(enableNetworkNS bool) *syscall.SysProcAttr 
 	sysProcAttr := l.syscall.CreateProcessGroup()
 
 	// Base namespaces that are always enabled
-	sysProcAttr.Cloneflags = syscall.CLONE_NEWPID | // PID namespace - ALWAYS isolated
-		syscall.CLONE_NEWNS | // Mount namespace - ALWAYS isolated
-		syscall.CLONE_NEWIPC | // IPC namespace - ALWAYS isolated
-		syscall.CLONE_NEWUTS // UTS namespace - ALWAYS isolated
+	sysProcAttr.Cloneflags = syscall.CLONE_NEWPID | // PID namespace ALWAYS isolated
+		syscall.CLONE_NEWNS | // Mount namespace ALWAYS isolated
+		syscall.CLONE_NEWIPC | // IPC namespace ALWAYS isolated
+		syscall.CLONE_NEWUTS | // UTS namespace ALWAYS isolated
+		syscall.CLONE_NEWCGROUP // Cgroup namespace MANDATORY
 
 	// Conditionally add network namespace
 	if enableNetworkNS {


### PR DESCRIPTION
* Give each job its own view of the cgroup hierarchy
* Hide other jobs' cgroups from each job's perspective
* Provide additional isolation between jobs