### PR TITLE
update the graceful shutdown timeout

### DIFF
--- a/internal/worker/auth/grpc_authorization_test.go
+++ b/internal/worker/auth/grpc_authorization_test.go
@@ -1,0 +1,399 @@
+package auth
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+	"testing"
+)
+
+// Helper function to create a mock context with peer information
+func createMockContext(organizationalUnits []string) context.Context {
+	// Create a mock certificate
+	cert := &x509.Certificate{
+		Subject: pkix.Name{
+			OrganizationalUnit: organizationalUnits,
+		},
+	}
+
+	// Create TLS info
+	tlsInfo := credentials.TLSInfo{
+		State: tls.ConnectionState{
+			PeerCertificates: []*x509.Certificate{cert},
+		},
+	}
+
+	// Create peer with TLS info
+	p := &peer.Peer{
+		AuthInfo: tlsInfo,
+	}
+
+	// Create context with peer
+	return peer.NewContext(context.Background(), p)
+}
+
+func createMockContextNoPeer() context.Context {
+	return context.Background()
+}
+
+func createMockContextNoTLS() context.Context {
+	p := &peer.Peer{
+		AuthInfo: nil, // No TLS info
+	}
+	return peer.NewContext(context.Background(), p)
+}
+
+func createMockContextNoCerts() context.Context {
+	tlsInfo := credentials.TLSInfo{
+		State: tls.ConnectionState{
+			PeerCertificates: []*x509.Certificate{}, // Empty certificates
+		},
+	}
+
+	p := &peer.Peer{
+		AuthInfo: tlsInfo,
+	}
+	return peer.NewContext(context.Background(), p)
+}
+
+func TestGrpcAuthorization_ExtractClientRole(t *testing.T) {
+	auth := NewGrpcAuthorization().(*grpcAuthorization)
+
+	tests := []struct {
+		name         string
+		context      context.Context
+		expectedRole ClientRole
+		expectError  bool
+	}{
+		{
+			name:         "Admin role",
+			context:      createMockContext([]string{"admin"}),
+			expectedRole: AdminRole,
+			expectError:  false,
+		},
+		{
+			name:         "Viewer role",
+			context:      createMockContext([]string{"viewer"}),
+			expectedRole: ViewerRole,
+			expectError:  false,
+		},
+		{
+			name:         "Admin role (case insensitive)",
+			context:      createMockContext([]string{"ADMIN"}),
+			expectedRole: AdminRole,
+			expectError:  false,
+		},
+		{
+			name:         "Viewer role (case insensitive)",
+			context:      createMockContext([]string{"VIEWER"}),
+			expectedRole: ViewerRole,
+			expectError:  false,
+		},
+		{
+			name:         "Multiple OUs with admin",
+			context:      createMockContext([]string{"something", "admin", "other"}),
+			expectedRole: AdminRole,
+			expectError:  false,
+		},
+		{
+			name:         "Unknown role",
+			context:      createMockContext([]string{"unknown"}),
+			expectedRole: UnknownRole,
+			expectError:  false,
+		},
+		{
+			name:         "Empty OUs",
+			context:      createMockContext([]string{}),
+			expectedRole: UnknownRole,
+			expectError:  false,
+		},
+		{
+			name:        "No peer information",
+			context:     createMockContextNoPeer(),
+			expectError: true,
+		},
+		{
+			name:        "No TLS information",
+			context:     createMockContextNoTLS(),
+			expectError: true,
+		},
+		{
+			name:        "No client certificates",
+			context:     createMockContextNoCerts(),
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			role, err := auth.extractClientRole(tt.context)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+				return
+			}
+
+			if role != tt.expectedRole {
+				t.Errorf("Expected role %v, got %v", tt.expectedRole, role)
+			}
+		})
+	}
+}
+
+func TestGrpcAuthorization_IsOperationAllowed(t *testing.T) {
+	auth := NewGrpcAuthorization().(*grpcAuthorization)
+
+	tests := []struct {
+		role      ClientRole
+		operation Operation
+		allowed   bool
+	}{
+		// Admin role - should allow all operations
+		{AdminRole, RunJobOp, true},
+		{AdminRole, GetJobOp, true},
+		{AdminRole, StopJobOp, true},
+		{AdminRole, ListJobsOp, true},
+		{AdminRole, StreamJobsOp, true},
+
+		// Viewer role - should allow only read operations
+		{ViewerRole, RunJobOp, false},
+		{ViewerRole, GetJobOp, true},
+		{ViewerRole, StopJobOp, false},
+		{ViewerRole, ListJobsOp, true},
+		{ViewerRole, StreamJobsOp, true},
+
+		// Unknown role - should not allow any operations
+		{UnknownRole, RunJobOp, false},
+		{UnknownRole, GetJobOp, false},
+		{UnknownRole, StopJobOp, false},
+		{UnknownRole, ListJobsOp, false},
+		{UnknownRole, StreamJobsOp, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.role)+"_"+string(tt.operation), func(t *testing.T) {
+			allowed := auth.isOperationAllowed(tt.role, tt.operation)
+			if allowed != tt.allowed {
+				t.Errorf("Expected %v for role %v and operation %v, got %v",
+					tt.allowed, tt.role, tt.operation, allowed)
+			}
+		})
+	}
+}
+
+func TestGrpcAuthorization_Authorized(t *testing.T) {
+	auth := NewGrpcAuthorization()
+
+	tests := []struct {
+		name         string
+		context      context.Context
+		operation    Operation
+		expectError  bool
+		expectedCode codes.Code
+	}{
+		{
+			name:        "Admin can run jobs",
+			context:     createMockContext([]string{"admin"}),
+			operation:   RunJobOp,
+			expectError: false,
+		},
+		{
+			name:        "Admin can get jobs",
+			context:     createMockContext([]string{"admin"}),
+			operation:   GetJobOp,
+			expectError: false,
+		},
+		{
+			name:        "Admin can stop jobs",
+			context:     createMockContext([]string{"admin"}),
+			operation:   StopJobOp,
+			expectError: false,
+		},
+		{
+			name:        "Admin can list jobs",
+			context:     createMockContext([]string{"admin"}),
+			operation:   ListJobsOp,
+			expectError: false,
+		},
+		{
+			name:        "Admin can stream jobs",
+			context:     createMockContext([]string{"admin"}),
+			operation:   StreamJobsOp,
+			expectError: false,
+		},
+		{
+			name:        "Viewer can get jobs",
+			context:     createMockContext([]string{"viewer"}),
+			operation:   GetJobOp,
+			expectError: false,
+		},
+		{
+			name:        "Viewer can list jobs",
+			context:     createMockContext([]string{"viewer"}),
+			operation:   ListJobsOp,
+			expectError: false,
+		},
+		{
+			name:        "Viewer can stream jobs",
+			context:     createMockContext([]string{"viewer"}),
+			operation:   StreamJobsOp,
+			expectError: false,
+		},
+		{
+			name:         "Viewer cannot run jobs",
+			context:      createMockContext([]string{"viewer"}),
+			operation:    RunJobOp,
+			expectError:  true,
+			expectedCode: codes.PermissionDenied,
+		},
+		{
+			name:         "Viewer cannot stop jobs",
+			context:      createMockContext([]string{"viewer"}),
+			operation:    StopJobOp,
+			expectError:  true,
+			expectedCode: codes.PermissionDenied,
+		},
+		{
+			name:         "Unknown role cannot access anything",
+			context:      createMockContext([]string{"unknown"}),
+			operation:    GetJobOp,
+			expectError:  true,
+			expectedCode: codes.PermissionDenied,
+		},
+		{
+			name:         "No peer information",
+			context:      createMockContextNoPeer(),
+			operation:    GetJobOp,
+			expectError:  true,
+			expectedCode: codes.Unauthenticated,
+		},
+		{
+			name:         "No TLS information",
+			context:      createMockContextNoTLS(),
+			operation:    GetJobOp,
+			expectError:  true,
+			expectedCode: codes.Unauthenticated,
+		},
+		{
+			name:         "No client certificates",
+			context:      createMockContextNoCerts(),
+			operation:    GetJobOp,
+			expectError:  true,
+			expectedCode: codes.Unauthenticated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := auth.Authorized(tt.context, tt.operation)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+					return
+				}
+
+				// Check error code
+				if st, ok := status.FromError(err); ok {
+					if st.Code() != tt.expectedCode {
+						t.Errorf("Expected error code %v, got %v", tt.expectedCode, st.Code())
+					}
+				} else {
+					t.Errorf("Expected gRPC status error, got %T", err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestClientRole_String(t *testing.T) {
+	tests := []struct {
+		role     ClientRole
+		expected string
+	}{
+		{AdminRole, "admin"},
+		{ViewerRole, "viewer"},
+		{UnknownRole, "unknown"},
+	}
+
+	for _, tt := range tests {
+		if string(tt.role) != tt.expected {
+			t.Errorf("Expected string representation %v, got %v", tt.expected, string(tt.role))
+		}
+	}
+}
+
+func TestOperation_String(t *testing.T) {
+	tests := []struct {
+		operation Operation
+		expected  string
+	}{
+		{RunJobOp, "run_job"},
+		{GetJobOp, "get_job"},
+		{StopJobOp, "stop_job"},
+		{ListJobsOp, "list_jobs"},
+		{StreamJobsOp, "stream_jobs"},
+	}
+
+	for _, tt := range tests {
+		if string(tt.operation) != tt.expected {
+			t.Errorf("Expected string representation %v, got %v", tt.expected, string(tt.operation))
+		}
+	}
+}
+
+// Benchmark tests
+func BenchmarkGrpcAuthorization_ExtractClientRole(b *testing.B) {
+	auth := NewGrpcAuthorization().(*grpcAuthorization)
+	ctx := createMockContext([]string{"admin"})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		auth.extractClientRole(ctx)
+	}
+}
+
+func BenchmarkGrpcAuthorization_IsOperationAllowed(b *testing.B) {
+	auth := NewGrpcAuthorization().(*grpcAuthorization)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		auth.isOperationAllowed(AdminRole, RunJobOp)
+	}
+}
+
+func BenchmarkGrpcAuthorization_Authorized(b *testing.B) {
+	auth := NewGrpcAuthorization()
+	ctx := createMockContext([]string{"admin"})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		auth.Authorized(ctx, RunJobOp)
+	}
+}
+
+func TestNewGrpcAuthorization(t *testing.T) {
+	auth := NewGrpcAuthorization()
+	if auth == nil {
+		t.Error("Expected non-nil authorization instance")
+	}
+
+	// Verify it implements the interface
+	var _ GrpcAuthorization = auth
+}

--- a/internal/worker/domain/job_test.go
+++ b/internal/worker/domain/job_test.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"testing"
+	"time"
 )
 
 func TestJobStateTransitions(t *testing.T) {
@@ -19,6 +20,9 @@ func TestJobStateTransitions(t *testing.T) {
 	}
 	if job.Status != StatusRunning {
 		t.Errorf("Expected status RUNNING, got %v", job.Status)
+	}
+	if job.Pid != 1234 {
+		t.Errorf("Expected PID 1234, got %v", job.Pid)
 	}
 
 	// test invalid transition: RUNNING -> RUNNING
@@ -38,27 +42,261 @@ func TestJobStateTransitions(t *testing.T) {
 	if job.EndTime == nil {
 		t.Error("Expected end time to be set")
 	}
+	if job.ExitCode != 0 {
+		t.Errorf("Expected exit code 0, got %v", job.ExitCode)
+	}
+}
+
+func TestJobFailTransitions(t *testing.T) {
+	tests := []struct {
+		name           string
+		initialStatus  JobStatus
+		exitCode       int32
+		expectError    bool
+		expectedStatus JobStatus
+	}{
+		{
+			name:           "RUNNING to FAILED",
+			initialStatus:  StatusRunning,
+			exitCode:       1,
+			expectError:    false,
+			expectedStatus: StatusFailed,
+		},
+		{
+			name:           "INITIALIZING to FAILED",
+			initialStatus:  StatusInitializing,
+			exitCode:       -1,
+			expectError:    false,
+			expectedStatus: StatusFailed,
+		},
+		{
+			name:          "COMPLETED to FAILED (invalid)",
+			initialStatus: StatusCompleted,
+			exitCode:      1,
+			expectError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &Job{
+				Id:     "test-fail",
+				Status: tt.initialStatus,
+			}
+
+			err := job.Fail(tt.exitCode)
+
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+
+			if !tt.expectError {
+				if job.Status != tt.expectedStatus {
+					t.Errorf("Expected status %v, got %v", tt.expectedStatus, job.Status)
+				}
+				if job.ExitCode != tt.exitCode {
+					t.Errorf("Expected exit code %v, got %v", tt.exitCode, job.ExitCode)
+				}
+				if job.EndTime == nil {
+					t.Error("Expected end time to be set")
+				}
+			}
+		})
+	}
+}
+
+func TestJobStopTransition(t *testing.T) {
+	job := &Job{
+		Id:     "test-stop",
+		Status: StatusRunning,
+		Pid:    1234,
+	}
+
+	err := job.Stop()
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	if job.Status != StatusStopped {
+		t.Errorf("Expected status STOPPED, got %v", job.Status)
+	}
+	if job.ExitCode != -1 {
+		t.Errorf("Expected exit code -1, got %v", job.ExitCode)
+	}
+	if job.EndTime == nil {
+		t.Error("Expected end time to be set")
+	}
+}
+
+func TestJobMarkAsRunningValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		pid         int32
+		expectError bool
+	}{
+		{"Valid PID", 1234, false},
+		{"Zero PID", 0, true},
+		{"Negative PID", -1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &Job{
+				Id:     "test-validation",
+				Status: StatusInitializing,
+			}
+
+			err := job.MarkAsRunning(tt.pid)
+
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
 }
 
 func TestJobDeepCopy(t *testing.T) {
+	endTime := time.Now()
 	original := &Job{
 		Id:      "test-1",
 		Command: "echo",
 		Args:    []string{"hello", "world"},
 		Status:  StatusRunning,
+		Pid:     1234,
+		Limits: ResourceLimits{
+			MaxCPU:    100,
+			MaxMemory: 512,
+			MaxIOBPS:  1000,
+		},
+		CgroupPath: "/sys/fs/cgroup/job-test-1",
+		StartTime:  time.Now(),
+		EndTime:    &endTime,
+		ExitCode:   0,
 	}
 
 	cp := original.DeepCopy()
 
-	// change the original
-	original.Args[0] = "goodbye"
-	original.Status = StatusCompleted
+	// Verify all fields are copied
+	if cp.Id != original.Id {
+		t.Errorf("ID not copied correctly: expected %v, got %v", original.Id, cp.Id)
+	}
+	if cp.Command != original.Command {
+		t.Errorf("Command not copied correctly")
+	}
+	if cp.Status != original.Status {
+		t.Errorf("Status not copied correctly")
+	}
+	if cp.Pid != original.Pid {
+		t.Errorf("PID not copied correctly")
+	}
+	if cp.ExitCode != original.ExitCode {
+		t.Errorf("ExitCode not copied correctly")
+	}
 
-	// check copy is not affected
+	// Test slice independence
+	original.Args[0] = "goodbye"
 	if cp.Args[0] != "hello" {
 		t.Error("Deep copy failed: args slice was not properly copied")
 	}
+
+	// Test status independence
+	original.Status = StatusCompleted
 	if cp.Status != StatusRunning {
 		t.Error("Deep copy failed: status was not properly copied")
+	}
+
+	// Test time pointer independence
+	if original.EndTime == cp.EndTime {
+		t.Error("EndTime should be different pointers")
+	}
+	if cp.EndTime == nil {
+		t.Error("EndTime should not be nil")
+	}
+	if !cp.EndTime.Equal(*original.EndTime) {
+		t.Error("EndTime values should be equal")
+	}
+}
+
+func TestJobIsRunning(t *testing.T) {
+	tests := []struct {
+		status   JobStatus
+		expected bool
+	}{
+		{StatusInitializing, false},
+		{StatusRunning, true},
+		{StatusCompleted, false},
+		{StatusFailed, false},
+		{StatusStopped, false},
+	}
+
+	for _, tt := range tests {
+		job := &Job{Status: tt.status}
+		if job.IsRunning() != tt.expected {
+			t.Errorf("IsRunning() for status %v: expected %v, got %v",
+				tt.status, tt.expected, job.IsRunning())
+		}
+	}
+}
+
+func TestJobIsCompleted(t *testing.T) {
+	tests := []struct {
+		status   JobStatus
+		expected bool
+	}{
+		{StatusInitializing, false},
+		{StatusRunning, false},
+		{StatusCompleted, true},
+		{StatusFailed, true},
+		{StatusStopped, true},
+	}
+
+	for _, tt := range tests {
+		job := &Job{Status: tt.status}
+		if job.IsCompleted() != tt.expected {
+			t.Errorf("IsCompleted() for status %v: expected %v, got %v",
+				tt.status, tt.expected, job.IsCompleted())
+		}
+	}
+}
+
+func TestJobDuration(t *testing.T) {
+	now := time.Now()
+
+	// Test running job
+	runningJob := &Job{
+		Status:    StatusRunning,
+		StartTime: now.Add(-5 * time.Second),
+	}
+	duration := runningJob.Duration()
+	if duration < 4*time.Second || duration > 6*time.Second {
+		t.Errorf("Expected duration around 5 seconds, got %v", duration)
+	}
+
+	// Test completed job
+	endTime := now.Add(-2 * time.Second)
+	completedJob := &Job{
+		Status:    StatusCompleted,
+		StartTime: now.Add(-5 * time.Second),
+		EndTime:   &endTime,
+	}
+	duration = completedJob.Duration()
+	expected := 3 * time.Second
+	if duration != expected {
+		t.Errorf("Expected duration %v, got %v", expected, duration)
+	}
+
+	// Test job that never started properly
+	neverStartedJob := &Job{
+		Status: StatusInitializing,
+	}
+	duration = neverStartedJob.Duration()
+	if duration != 0 {
+		t.Errorf("Expected duration 0, got %v", duration)
 	}
 }

--- a/internal/worker/interfaces/interfacesfakes/fake_store.go
+++ b/internal/worker/interfaces/interfacesfakes/fake_store.go
@@ -120,7 +120,7 @@ func (fake *FakeStore) GetJob(arg1 string) (*domain.Job, bool) {
 	}{arg1})
 	stub := fake.GetJobStub
 	fakeReturns := fake.getJobReturns
-	fake.recordInvocation("GetJobStatus", []interface{}{arg1})
+	fake.recordInvocation("GetJob", []interface{}{arg1})
 	fake.getJobMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)

--- a/internal/worker/jobworker/linux/worker.go
+++ b/internal/worker/jobworker/linux/worker.go
@@ -245,8 +245,8 @@ func (w *Worker) startProcessWithUserNamespace(ctx context.Context, job *domain.
 		InitPath:      initPath,
 		Environment:   env,
 		SysProcAttr:   sysProcAttr,
-		Stdout:        New(w.store, job.Id),
-		Stderr:        New(w.store, job.Id),
+		Stdout:        NewWrite(w.store, job.Id),
+		Stderr:        NewWrite(w.store, job.Id),
 		NamespacePath: "",    // No separate network namespace needed
 		NeedsNSJoin:   false, // User namespace is created, not joined
 		JobID:         job.Id,

--- a/internal/worker/jobworker/linux/writer.go
+++ b/internal/worker/jobworker/linux/writer.go
@@ -9,7 +9,7 @@ type OutputWriter struct {
 	store interfaces.Store
 }
 
-func New(store interfaces.Store, jobId string) *OutputWriter {
+func NewWrite(store interfaces.Store, jobId string) *OutputWriter {
 	return &OutputWriter{store: store, jobId: jobId}
 }
 

--- a/internal/worker/mappers/job_mapper_test.go
+++ b/internal/worker/mappers/job_mapper_test.go
@@ -1,0 +1,413 @@
+package mappers
+
+import (
+	"job-worker/internal/worker/domain"
+	"testing"
+	"time"
+)
+
+func TestDomainToProtobuf(t *testing.T) {
+	startTime := time.Now()
+	endTime := startTime.Add(5 * time.Second)
+
+	job := &domain.Job{
+		Id:      "test-job-1",
+		Command: "echo",
+		Args:    []string{"hello", "world"},
+		Limits: domain.ResourceLimits{
+			MaxCPU:    100,
+			MaxMemory: 512,
+			MaxIOBPS:  1000,
+		},
+		Status:    domain.StatusCompleted,
+		StartTime: startTime,
+		EndTime:   &endTime,
+		ExitCode:  0,
+	}
+
+	pbJob := DomainToProtobuf(job)
+
+	// Verify all fields are mapped correctly
+	if pbJob.Id != job.Id {
+		t.Errorf("Expected ID %v, got %v", job.Id, pbJob.Id)
+	}
+	if pbJob.Command != job.Command {
+		t.Errorf("Expected command %v, got %v", job.Command, pbJob.Command)
+	}
+	if len(pbJob.Args) != len(job.Args) {
+		t.Errorf("Expected %v args, got %v", len(job.Args), len(pbJob.Args))
+	}
+	for i, arg := range job.Args {
+		if pbJob.Args[i] != arg {
+			t.Errorf("Expected arg[%d] %v, got %v", i, arg, pbJob.Args[i])
+		}
+	}
+	if pbJob.MaxCPU != job.Limits.MaxCPU {
+		t.Errorf("Expected MaxCPU %v, got %v", job.Limits.MaxCPU, pbJob.MaxCPU)
+	}
+	if pbJob.MaxMemory != job.Limits.MaxMemory {
+		t.Errorf("Expected MaxMemory %v, got %v", job.Limits.MaxMemory, pbJob.MaxMemory)
+	}
+	if pbJob.MaxIOBPS != job.Limits.MaxIOBPS {
+		t.Errorf("Expected MaxIOBPS %v, got %v", job.Limits.MaxIOBPS, pbJob.MaxIOBPS)
+	}
+	if pbJob.Status != string(job.Status) {
+		t.Errorf("Expected status %v, got %v", string(job.Status), pbJob.Status)
+	}
+	if pbJob.ExitCode != job.ExitCode {
+		t.Errorf("Expected exit code %v, got %v", job.ExitCode, pbJob.ExitCode)
+	}
+
+	// Verify time formatting
+	expectedStartTime := startTime.Format("2006-01-02T15:04:05Z07:00")
+	if pbJob.StartTime != expectedStartTime {
+		t.Errorf("Expected start time %v, got %v", expectedStartTime, pbJob.StartTime)
+	}
+
+	expectedEndTime := endTime.Format("2006-01-02T15:04:05Z07:00")
+	if pbJob.EndTime != expectedEndTime {
+		t.Errorf("Expected end time %v, got %v", expectedEndTime, pbJob.EndTime)
+	}
+}
+
+func TestDomainToProtobuf_NoEndTime(t *testing.T) {
+	job := &domain.Job{
+		Id:        "running-job",
+		Command:   "sleep",
+		Args:      []string{"60"},
+		Status:    domain.StatusRunning,
+		StartTime: time.Now(),
+		EndTime:   nil, // Running job has no end time
+	}
+
+	pbJob := DomainToProtobuf(job)
+
+	if pbJob.EndTime != "" {
+		t.Errorf("Expected empty end time for running job, got %v", pbJob.EndTime)
+	}
+}
+
+func TestDomainToProtobuf_EmptyArgs(t *testing.T) {
+	job := &domain.Job{
+		Id:        "no-args-job",
+		Command:   "pwd",
+		Args:      []string{}, // Empty args
+		Status:    domain.StatusCompleted,
+		StartTime: time.Now(),
+	}
+
+	pbJob := DomainToProtobuf(job)
+
+	if len(pbJob.Args) != 0 {
+		t.Errorf("Expected empty args, got %v", pbJob.Args)
+	}
+}
+
+func TestDomainToRunJobResponse(t *testing.T) {
+	job := &domain.Job{
+		Id:      "run-job-test",
+		Command: "echo",
+		Args:    []string{"test"},
+		Limits: domain.ResourceLimits{
+			MaxCPU:    50,
+			MaxMemory: 256,
+			MaxIOBPS:  500,
+		},
+		Status:    domain.StatusRunning,
+		StartTime: time.Now(),
+		ExitCode:  0,
+	}
+
+	response := DomainToRunJobResponse(job)
+
+	// Verify it's a proper RunJobRes
+	if response.Id != job.Id {
+		t.Errorf("Expected ID %v, got %v", job.Id, response.Id)
+	}
+	if response.Command != job.Command {
+		t.Errorf("Expected command %v, got %v", job.Command, response.Command)
+	}
+	if response.Status != string(job.Status) {
+		t.Errorf("Expected status %v, got %v", string(job.Status), response.Status)
+	}
+}
+
+func TestDomainToGetJobStatusResponse(t *testing.T) {
+	endTime := time.Now()
+	job := &domain.Job{
+		Id:        "status-job-test",
+		Command:   "ls",
+		Args:      []string{"-la"},
+		Status:    domain.StatusCompleted,
+		StartTime: time.Now().Add(-1 * time.Minute),
+		EndTime:   &endTime,
+		ExitCode:  0,
+	}
+
+	response := DomainToGetJobStatusResponse(job)
+
+	// Verify it's a proper GetJobStatusRes
+	if response.Id != job.Id {
+		t.Errorf("Expected ID %v, got %v", job.Id, response.Id)
+	}
+	if response.Status != string(job.Status) {
+		t.Errorf("Expected status %v, got %v", string(job.Status), response.Status)
+	}
+	if response.ExitCode != job.ExitCode {
+		t.Errorf("Expected exit code %v, got %v", job.ExitCode, response.ExitCode)
+	}
+	if response.EndTime == "" {
+		t.Error("Expected end time to be set for completed job")
+	}
+}
+
+func TestDomainToStopJobResponse(t *testing.T) {
+	endTime := time.Now()
+	job := &domain.Job{
+		Id:       "stop-job-test",
+		Status:   domain.StatusStopped,
+		EndTime:  &endTime,
+		ExitCode: -1,
+	}
+
+	response := DomainToStopJobResponse(job)
+
+	// Verify it's a proper StopJobRes
+	if response.Id != job.Id {
+		t.Errorf("Expected ID %v, got %v", job.Id, response.Id)
+	}
+	if response.Status != string(job.Status) {
+		t.Errorf("Expected status %v, got %v", string(job.Status), response.Status)
+	}
+	if response.ExitCode != job.ExitCode {
+		t.Errorf("Expected exit code %v, got %v", job.ExitCode, response.ExitCode)
+	}
+	if response.EndTime == "" {
+		t.Error("Expected end time to be set for stopped job")
+	}
+}
+
+func TestDomainToStopJobResponse_NoEndTime(t *testing.T) {
+	job := &domain.Job{
+		Id:       "stop-job-no-end",
+		Status:   domain.StatusStopped,
+		EndTime:  nil, // No end time set
+		ExitCode: -1,
+	}
+
+	response := DomainToStopJobResponse(job)
+
+	if response.EndTime != "" {
+		t.Errorf("Expected empty end time, got %v", response.EndTime)
+	}
+}
+
+// Test all status values mapping correctly
+func TestStatusMapping(t *testing.T) {
+	statuses := []domain.JobStatus{
+		domain.StatusInitializing,
+		domain.StatusRunning,
+		domain.StatusCompleted,
+		domain.StatusFailed,
+		domain.StatusStopped,
+	}
+
+	for _, status := range statuses {
+		job := &domain.Job{
+			Id:        "status-test",
+			Command:   "echo",
+			Status:    status,
+			StartTime: time.Now(),
+		}
+
+		// Test all mapper functions
+		pbJob := DomainToProtobuf(job)
+		runJobRes := DomainToRunJobResponse(job)
+		statusRes := DomainToGetJobStatusResponse(job)
+		stopRes := DomainToStopJobResponse(job)
+
+		expectedStatus := string(status)
+
+		if pbJob.Status != expectedStatus {
+			t.Errorf("DomainToProtobuf: Expected status %v, got %v", expectedStatus, pbJob.Status)
+		}
+		if runJobRes.Status != expectedStatus {
+			t.Errorf("DomainToRunJobResponse: Expected status %v, got %v", expectedStatus, runJobRes.Status)
+		}
+		if statusRes.Status != expectedStatus {
+			t.Errorf("DomainToGetJobStatusResponse: Expected status %v, got %v", expectedStatus, statusRes.Status)
+		}
+		if stopRes.Status != expectedStatus {
+			t.Errorf("DomainToStopJobResponse: Expected status %v, got %v", expectedStatus, stopRes.Status)
+		}
+	}
+}
+
+// Test edge cases with resource limits
+func TestResourceLimitsMapping(t *testing.T) {
+	tests := []struct {
+		name   string
+		limits domain.ResourceLimits
+	}{
+		{
+			name: "zero limits",
+			limits: domain.ResourceLimits{
+				MaxCPU:    0,
+				MaxMemory: 0,
+				MaxIOBPS:  0,
+			},
+		},
+		{
+			name: "negative limits",
+			limits: domain.ResourceLimits{
+				MaxCPU:    -1,
+				MaxMemory: -1,
+				MaxIOBPS:  -1,
+			},
+		},
+		{
+			name: "max values",
+			limits: domain.ResourceLimits{
+				MaxCPU:    2147483647, // int32 max
+				MaxMemory: 2147483647,
+				MaxIOBPS:  2147483647,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &domain.Job{
+				Id:        "limits-test",
+				Command:   "echo",
+				Limits:    tt.limits,
+				Status:    domain.StatusRunning,
+				StartTime: time.Now(),
+			}
+
+			pbJob := DomainToProtobuf(job)
+
+			if pbJob.MaxCPU != tt.limits.MaxCPU {
+				t.Errorf("Expected MaxCPU %v, got %v", tt.limits.MaxCPU, pbJob.MaxCPU)
+			}
+			if pbJob.MaxMemory != tt.limits.MaxMemory {
+				t.Errorf("Expected MaxMemory %v, got %v", tt.limits.MaxMemory, pbJob.MaxMemory)
+			}
+			if pbJob.MaxIOBPS != tt.limits.MaxIOBPS {
+				t.Errorf("Expected MaxIOBPS %v, got %v", tt.limits.MaxIOBPS, pbJob.MaxIOBPS)
+			}
+		})
+	}
+}
+
+// Test time formatting edge cases
+func TestTimeFormatting(t *testing.T) {
+	// Test with timezone
+	location, _ := time.LoadLocation("America/New_York")
+	timeInTZ := time.Date(2023, 12, 25, 15, 30, 45, 123456789, location)
+
+	job := &domain.Job{
+		Id:        "time-test",
+		Command:   "echo",
+		Status:    domain.StatusCompleted,
+		StartTime: timeInTZ,
+		EndTime:   &timeInTZ,
+	}
+
+	pbJob := DomainToProtobuf(job)
+
+	// Verify the time format includes timezone
+	expectedFormat := timeInTZ.Format("2006-01-02T15:04:05Z07:00")
+	if pbJob.StartTime != expectedFormat {
+		t.Errorf("Expected start time %v, got %v", expectedFormat, pbJob.StartTime)
+	}
+	if pbJob.EndTime != expectedFormat {
+		t.Errorf("Expected end time %v, got %v", expectedFormat, pbJob.EndTime)
+	}
+}
+
+// Test args slice handling
+func TestArgsSliceHandling(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "single arg",
+			args: []string{"hello"},
+		},
+		{
+			name: "multiple args",
+			args: []string{"echo", "-n", "hello world"},
+		},
+		{
+			name: "args with special characters",
+			args: []string{"echo", "hello\nworld", "test\ttab", "quote\"test"},
+		},
+		{
+			name: "empty string args",
+			args: []string{"", "not-empty", ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &domain.Job{
+				Id:        "args-test",
+				Command:   "echo",
+				Args:      tt.args,
+				Status:    domain.StatusRunning,
+				StartTime: time.Now(),
+			}
+
+			pbJob := DomainToProtobuf(job)
+
+			if len(pbJob.Args) != len(tt.args) {
+				t.Errorf("Expected %d args, got %d", len(tt.args), len(pbJob.Args))
+			}
+
+			for i, expectedArg := range tt.args {
+				if i < len(pbJob.Args) && pbJob.Args[i] != expectedArg {
+					t.Errorf("Expected arg[%d] = %q, got %q", i, expectedArg, pbJob.Args[i])
+				}
+			}
+		})
+	}
+}
+
+// Benchmark tests
+func BenchmarkDomainToProtobuf(b *testing.B) {
+	job := &domain.Job{
+		Id:      "benchmark-job",
+		Command: "echo",
+		Args:    []string{"hello", "world", "from", "benchmark"},
+		Limits: domain.ResourceLimits{
+			MaxCPU:    100,
+			MaxMemory: 512,
+			MaxIOBPS:  1000,
+		},
+		Status:    domain.StatusCompleted,
+		StartTime: time.Now(),
+		ExitCode:  0,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		DomainToProtobuf(job)
+	}
+}
+
+func BenchmarkDomainToRunJobResponse(b *testing.B) {
+	job := &domain.Job{
+		Id:        "benchmark-run-job",
+		Command:   "echo",
+		Args:      []string{"test"},
+		Status:    domain.StatusRunning,
+		StartTime: time.Now(),
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		DomainToRunJobResponse(job)
+	}
+}

--- a/internal/worker/store/store_test.go
+++ b/internal/worker/store/store_test.go
@@ -1,0 +1,359 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"job-worker/internal/worker/domain"
+	"sync"
+	"testing"
+	"time"
+)
+
+// mockDomainStreamer for testing
+type mockDomainStreamer struct {
+	receivedData       [][]byte
+	receivedKeepalives int
+	ctx                context.Context
+	mu                 sync.Mutex
+}
+
+func (m *mockDomainStreamer) SendData(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.receivedData = append(m.receivedData, data)
+	return nil
+}
+
+func (m *mockDomainStreamer) SendKeepalive() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.receivedKeepalives++
+	return nil
+}
+
+func (m *mockDomainStreamer) Context() context.Context {
+	return m.ctx
+}
+
+func (m *mockDomainStreamer) GetReceivedData() [][]byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([][]byte, len(m.receivedData))
+	copy(result, m.receivedData)
+	return result
+}
+
+func TestStore_CreateAndGetJob(t *testing.T) {
+	store := New()
+
+	job := &domain.Job{
+		Id:      "test-job-1",
+		Command: "echo",
+		Args:    []string{"hello"},
+		Status:  domain.StatusInitializing,
+		Limits: domain.ResourceLimits{
+			MaxCPU:    100,
+			MaxMemory: 512,
+			MaxIOBPS:  1000,
+		},
+		StartTime: time.Now(),
+	}
+
+	// Test creating a job
+	store.CreateNewJob(job)
+
+	// Test getting the job
+	retrievedJob, exists := store.GetJob("test-job-1")
+	if !exists {
+		t.Fatal("Expected job to exist")
+	}
+
+	if retrievedJob.Id != job.Id {
+		t.Errorf("Expected job ID %v, got %v", job.Id, retrievedJob.Id)
+	}
+	if retrievedJob.Command != job.Command {
+		t.Errorf("Expected command %v, got %v", job.Command, retrievedJob.Command)
+	}
+
+	// Test getting non-existent job
+	_, exists = store.GetJob("non-existent")
+	if exists {
+		t.Error("Expected job to not exist")
+	}
+}
+
+func TestStore_CreateDuplicateJob(t *testing.T) {
+	store := New()
+
+	job := &domain.Job{
+		Id:      "duplicate-job",
+		Command: "echo",
+		Status:  domain.StatusInitializing,
+	}
+
+	// Create job twice
+	store.CreateNewJob(job)
+	store.CreateNewJob(job)
+
+	// Should still only have one job
+	jobs := store.ListJobs()
+	if len(jobs) != 1 {
+		t.Errorf("Expected 1 job, got %v", len(jobs))
+	}
+}
+
+func TestStore_UpdateJob(t *testing.T) {
+	store := New()
+
+	job := &domain.Job{
+		Id:      "update-test",
+		Command: "echo",
+		Status:  domain.StatusInitializing,
+	}
+
+	store.CreateNewJob(job)
+
+	// Update the job
+	updatedJob := job.DeepCopy()
+	updatedJob.MarkAsRunning(1234)
+
+	store.UpdateJob(updatedJob)
+
+	// Retrieve and verify update
+	retrievedJob, exists := store.GetJob("update-test")
+	if !exists {
+		t.Fatal("Expected job to exist")
+	}
+
+	if retrievedJob.Status != domain.StatusRunning {
+		t.Errorf("Expected status RUNNING, got %v", retrievedJob.Status)
+	}
+	if retrievedJob.Pid != 1234 {
+		t.Errorf("Expected PID 1234, got %v", retrievedJob.Pid)
+	}
+}
+
+func TestStore_ListJobs(t *testing.T) {
+	store := New()
+
+	// Create multiple jobs
+	jobs := []*domain.Job{
+		{Id: "job-1", Command: "echo", Status: domain.StatusRunning},
+		{Id: "job-2", Command: "ls", Status: domain.StatusCompleted},
+		{Id: "job-3", Command: "pwd", Status: domain.StatusFailed},
+	}
+
+	for _, job := range jobs {
+		store.CreateNewJob(job)
+	}
+
+	// List all jobs
+	listedJobs := store.ListJobs()
+	if len(listedJobs) != 3 {
+		t.Errorf("Expected 3 jobs, got %v", len(listedJobs))
+	}
+
+	// Check that all jobs are present
+	jobIds := make(map[string]bool)
+	for _, job := range listedJobs {
+		jobIds[job.Id] = true
+	}
+
+	for _, expectedJob := range jobs {
+		if !jobIds[expectedJob.Id] {
+			t.Errorf("Expected job %v to be in list", expectedJob.Id)
+		}
+	}
+}
+
+func TestStore_WriteToBuffer(t *testing.T) {
+	store := New()
+
+	job := &domain.Job{
+		Id:      "buffer-test",
+		Command: "echo",
+		Status:  domain.StatusRunning,
+	}
+
+	store.CreateNewJob(job)
+
+	// Write to buffer
+	testData := []byte("Hello, World!")
+	store.WriteToBuffer("buffer-test", testData)
+
+	// Get output
+	output, isRunning, err := store.GetOutput("buffer-test")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !isRunning {
+		t.Error("Expected job to be running")
+	}
+	if string(output) != string(testData) {
+		t.Errorf("Expected output %v, got %v", string(testData), string(output))
+	}
+}
+
+func TestStore_WriteToNonExistentJob(t *testing.T) {
+	store := New()
+
+	// Should not panic when writing to non-existent job
+	store.WriteToBuffer("non-existent", []byte("test"))
+
+	// This test passes if no panic occurs
+}
+
+func TestStore_GetOutputNonExistentJob(t *testing.T) {
+	store := New()
+
+	_, _, err := store.GetOutput("non-existent")
+	if err == nil {
+		t.Error("Expected error for non-existent job")
+	}
+}
+
+func TestStore_SendUpdatesToClientCancellation(t *testing.T) {
+	store := New()
+
+	job := &domain.Job{
+		Id:      "cancel-test",
+		Command: "echo",
+		Status:  domain.StatusRunning,
+	}
+
+	store.CreateNewJob(job)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	mockStreamer := &mockDomainStreamer{ctx: ctx}
+
+	// Start streaming
+	errCh := make(chan error, 1)
+	go func() {
+		err := store.SendUpdatesToClient(ctx, "cancel-test", mockStreamer)
+		errCh <- err
+	}()
+
+	// Cancel context
+	cancel()
+
+	// Should receive cancellation error
+	select {
+	case err := <-errCh:
+		if err != context.Canceled {
+			t.Errorf("Expected context.Canceled, got %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Error("Stream did not handle cancellation in time")
+	}
+}
+
+func TestStore_SendUpdatesToNonExistentJob(t *testing.T) {
+	store := New()
+
+	ctx := context.Background()
+	mockStreamer := &mockDomainStreamer{ctx: ctx}
+
+	err := store.SendUpdatesToClient(ctx, "non-existent", mockStreamer)
+	if err == nil {
+		t.Error("Expected error for non-existent job")
+	}
+}
+
+func TestStore_SendUpdatesToNonRunningJob(t *testing.T) {
+	store := New()
+
+	job := &domain.Job{
+		Id:      "completed-job",
+		Command: "echo",
+		Status:  domain.StatusCompleted,
+	}
+
+	store.CreateNewJob(job)
+
+	ctx := context.Background()
+	mockStreamer := &mockDomainStreamer{ctx: ctx}
+
+	err := store.SendUpdatesToClient(ctx, "completed-job", mockStreamer)
+	if err != nil {
+		t.Errorf("Expected no error for completed job, got %v", err)
+	}
+}
+
+func TestStore_ConcurrentAccess(t *testing.T) {
+	store := New()
+
+	// Test concurrent job creation
+	var wg sync.WaitGroup
+	numJobs := 100
+
+	for i := 0; i < numJobs; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			job := &domain.Job{
+				Id:      fmt.Sprintf("concurrent-%d", id),
+				Command: "echo",
+				Status:  domain.StatusInitializing,
+			}
+			store.CreateNewJob(job)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify all jobs were created
+	jobs := store.ListJobs()
+	if len(jobs) != numJobs {
+		t.Errorf("Expected %v jobs, got %v", numJobs, len(jobs))
+	}
+}
+
+// Benchmark tests
+func BenchmarkStore_CreateJob(b *testing.B) {
+	store := New()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		job := &domain.Job{
+			Id:      fmt.Sprintf("bench-%d", i),
+			Command: "echo",
+			Status:  domain.StatusInitializing,
+		}
+		store.CreateNewJob(job)
+	}
+}
+
+func BenchmarkStore_GetJob(b *testing.B) {
+	store := New()
+
+	// Create test job
+	job := &domain.Job{
+		Id:      "bench-get",
+		Command: "echo",
+		Status:  domain.StatusInitializing,
+	}
+	store.CreateNewJob(job)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		store.GetJob("bench-get")
+	}
+}
+
+func BenchmarkStore_WriteToBuffer(b *testing.B) {
+	store := New()
+
+	job := &domain.Job{
+		Id:      "bench-write",
+		Command: "echo",
+		Status:  domain.StatusRunning,
+	}
+	store.CreateNewJob(job)
+
+	testData := []byte("benchmark data")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		store.WriteToBuffer("bench-write", testData)
+	}
+}

--- a/internal/worker/store/task_test.go
+++ b/internal/worker/store/task_test.go
@@ -1,0 +1,385 @@
+package store
+
+import (
+	"job-worker/internal/worker/domain"
+	"testing"
+	"time"
+)
+
+func TestTask_NewTask(t *testing.T) {
+	job := &domain.Job{
+		Id:      "task-test-1",
+		Command: "echo",
+		Args:    []string{"hello"},
+		Status:  domain.StatusInitializing,
+	}
+
+	task := NewTask(job)
+
+	if task.id != job.Id {
+		t.Errorf("Expected task ID %v, got %v", job.Id, task.id)
+	}
+
+	retrievedJob := task.GetJob()
+	if retrievedJob.Id != job.Id {
+		t.Errorf("Expected job ID %v, got %v", job.Id, retrievedJob.Id)
+	}
+
+	// Verify it's a deep copy
+	if retrievedJob == job {
+		t.Error("Expected deep copy, got same reference")
+	}
+}
+
+func TestTask_GetJob(t *testing.T) {
+	job := &domain.Job{
+		Id:      "get-job-test",
+		Command: "echo",
+		Status:  domain.StatusRunning,
+		Pid:     1234,
+	}
+
+	task := NewTask(job)
+	retrievedJob := task.GetJob()
+
+	// Verify all fields are copied correctly
+	if retrievedJob.Id != job.Id {
+		t.Errorf("Expected ID %v, got %v", job.Id, retrievedJob.Id)
+	}
+	if retrievedJob.Command != job.Command {
+		t.Errorf("Expected command %v, got %v", job.Command, retrievedJob.Command)
+	}
+	if retrievedJob.Status != job.Status {
+		t.Errorf("Expected status %v, got %v", job.Status, retrievedJob.Status)
+	}
+	if retrievedJob.Pid != job.Pid {
+		t.Errorf("Expected PID %v, got %v", job.Pid, retrievedJob.Pid)
+	}
+
+	// Verify independence
+	retrievedJob.Status = domain.StatusCompleted
+	secondRetrieved := task.GetJob()
+	if secondRetrieved.Status == domain.StatusCompleted {
+		t.Error("Expected job to be independent of returned copy")
+	}
+}
+
+func TestTask_UpdateJob(t *testing.T) {
+	originalJob := &domain.Job{
+		Id:      "update-test",
+		Command: "echo",
+		Status:  domain.StatusInitializing,
+	}
+
+	task := NewTask(originalJob)
+
+	// Update job
+	updatedJob := originalJob.DeepCopy()
+	updatedJob.MarkAsRunning(5678)
+
+	task.UpdateJob(updatedJob)
+
+	// Verify update
+	retrievedJob := task.GetJob()
+	if retrievedJob.Status != domain.StatusRunning {
+		t.Errorf("Expected status RUNNING, got %v", retrievedJob.Status)
+	}
+	if retrievedJob.Pid != 5678 {
+		t.Errorf("Expected PID 5678, got %v", retrievedJob.Pid)
+	}
+}
+
+func TestTask_WriteToBuffer(t *testing.T) {
+	job := &domain.Job{
+		Id:      "buffer-test",
+		Command: "echo",
+		Status:  domain.StatusRunning,
+	}
+
+	task := NewTask(job)
+
+	// Write data to buffer
+	testData := []byte("Hello, World!")
+	task.WriteToBuffer(testData)
+
+	// Retrieve buffer
+	buffer := task.GetBuffer()
+	if string(buffer) != string(testData) {
+		t.Errorf("Expected buffer %v, got %v", string(testData), string(buffer))
+	}
+}
+
+func TestTask_WriteToBufferMultiple(t *testing.T) {
+	job := &domain.Job{
+		Id:      "multi-buffer-test",
+		Command: "echo",
+		Status:  domain.StatusRunning,
+	}
+
+	task := NewTask(job)
+
+	// Write multiple chunks
+	chunks := [][]byte{
+		[]byte("First "),
+		[]byte("Second "),
+		[]byte("Third"),
+	}
+
+	for _, chunk := range chunks {
+		task.WriteToBuffer(chunk)
+	}
+
+	// Verify accumulated buffer
+	buffer := task.GetBuffer()
+	expected := "First Second Third"
+	if string(buffer) != expected {
+		t.Errorf("Expected buffer %v, got %v", expected, string(buffer))
+	}
+}
+
+func TestTask_WriteToBufferEmpty(t *testing.T) {
+	job := &domain.Job{
+		Id:      "empty-buffer-test",
+		Command: "echo",
+		Status:  domain.StatusRunning,
+	}
+
+	task := NewTask(job)
+
+	// Write empty data (should be ignored)
+	task.WriteToBuffer([]byte{})
+
+	// Buffer should remain empty
+	buffer := task.GetBuffer()
+	if buffer != nil {
+		t.Errorf("Expected nil buffer, got %v", buffer)
+	}
+}
+
+func TestTask_GetBufferEmpty(t *testing.T) {
+	job := &domain.Job{
+		Id:      "empty-get-test",
+		Command: "echo",
+		Status:  domain.StatusRunning,
+	}
+
+	task := NewTask(job)
+
+	// Get empty buffer
+	buffer := task.GetBuffer()
+	if buffer != nil {
+		t.Errorf("Expected nil buffer, got %v", buffer)
+	}
+}
+
+func TestTask_SubscribeAndPublish(t *testing.T) {
+	job := &domain.Job{
+		Id:      "subscribe-test",
+		Command: "echo",
+		Status:  domain.StatusRunning,
+	}
+
+	task := NewTask(job)
+
+	// Subscribe to updates
+	updates, unsubscribe := task.Subscribe()
+	defer unsubscribe()
+
+	// Publish an update
+	testUpdate := Update{
+		JobID:    "subscribe-test",
+		LogChunk: []byte("test log"),
+		Status:   "RUNNING",
+	}
+
+	go task.Publish(testUpdate)
+
+	// Receive update
+	select {
+	case receivedUpdate := <-updates:
+		if receivedUpdate.JobID != testUpdate.JobID {
+			t.Errorf("Expected JobID %v, got %v", testUpdate.JobID, receivedUpdate.JobID)
+		}
+		if string(receivedUpdate.LogChunk) != string(testUpdate.LogChunk) {
+			t.Errorf("Expected LogChunk %v, got %v", string(testUpdate.LogChunk), string(receivedUpdate.LogChunk))
+		}
+		if receivedUpdate.Status != testUpdate.Status {
+			t.Errorf("Expected Status %v, got %v", testUpdate.Status, receivedUpdate.Status)
+		}
+	case <-time.After(1 * time.Second):
+		t.Error("Did not receive update in time")
+	}
+}
+
+func TestTask_MultipleSubscribers(t *testing.T) {
+	job := &domain.Job{
+		Id:      "multi-subscribe-test",
+		Command: "echo",
+		Status:  domain.StatusRunning,
+	}
+
+	task := NewTask(job)
+
+	// Create multiple subscribers
+	numSubscribers := 3
+	subscribers := make([]<-chan Update, numSubscribers)
+	unsubscribers := make([]func(), numSubscribers)
+
+	for i := 0; i < numSubscribers; i++ {
+		updates, unsubscribe := task.Subscribe()
+		subscribers[i] = updates
+		unsubscribers[i] = unsubscribe
+	}
+
+	defer func() {
+		for _, unsubscribe := range unsubscribers {
+			unsubscribe()
+		}
+	}()
+
+	// Publish update
+	testUpdate := Update{
+		JobID:    "multi-subscribe-test",
+		LogChunk: []byte("broadcast message"),
+	}
+
+	go task.Publish(testUpdate)
+
+	// All subscribers should receive the update
+	received := 0
+	timeout := time.After(1 * time.Second)
+
+	for i := 0; i < numSubscribers; i++ {
+		select {
+		case update := <-subscribers[i]:
+			if string(update.LogChunk) == string(testUpdate.LogChunk) {
+				received++
+			}
+		case <-timeout:
+			t.Error("Timeout waiting for updates")
+			return
+		}
+	}
+
+	if received != numSubscribers {
+		t.Errorf("Expected %v subscribers to receive update, got %v", numSubscribers, received)
+	}
+}
+
+func TestTask_UnsubscribeRemovesSubscriber(t *testing.T) {
+	job := &domain.Job{
+		Id:      "unsubscribe-test",
+		Command: "echo",
+		Status:  domain.StatusRunning,
+	}
+
+	task := NewTask(job)
+
+	// Subscribe and immediately unsubscribe
+	_, unsubscribe := task.Subscribe()
+	unsubscribe()
+
+	// Publish update - should not block
+	testUpdate := Update{
+		JobID:    "unsubscribe-test",
+		LogChunk: []byte("should not block"),
+	}
+
+	// This should complete quickly since there are no subscribers
+	done := make(chan bool)
+	go func() {
+		task.Publish(testUpdate)
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Success - publish completed quickly
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Publish took too long - subscriber not properly removed")
+	}
+}
+
+func TestTask_IsRunning(t *testing.T) {
+	tests := []struct {
+		status   domain.JobStatus
+		expected bool
+	}{
+		{domain.StatusInitializing, false},
+		{domain.StatusRunning, true},
+		{domain.StatusCompleted, false},
+		{domain.StatusFailed, false},
+		{domain.StatusStopped, false},
+	}
+
+	for _, tt := range tests {
+		job := &domain.Job{
+			Id:     "running-test",
+			Status: tt.status,
+		}
+
+		task := NewTask(job)
+		if task.IsRunning() != tt.expected {
+			t.Errorf("IsRunning() for status %v: expected %v, got %v",
+				tt.status, tt.expected, task.IsRunning())
+		}
+	}
+}
+
+func TestTask_Shutdown(t *testing.T) {
+	job := &domain.Job{
+		Id:      "shutdown-test",
+		Command: "echo",
+		Status:  domain.StatusRunning,
+	}
+
+	task := NewTask(job)
+
+	// Create subscriber
+	updates, unsubscribe := task.Subscribe()
+	defer unsubscribe()
+
+	// Shutdown task
+	go task.Shutdown()
+
+	// Channel should be closed
+	select {
+	case _, ok := <-updates:
+		if ok {
+			t.Error("Expected channel to be closed")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Channel was not closed in time")
+	}
+}
+
+func TestTask_WriteToBufferWithSubscriber(t *testing.T) {
+	job := &domain.Job{
+		Id:      "write-subscriber-test",
+		Command: "echo",
+		Status:  domain.StatusRunning,
+	}
+
+	task := NewTask(job)
+
+	// Subscribe to updates
+	updates, unsubscribe := task.Subscribe()
+	defer unsubscribe()
+
+	// Write to buffer (should trigger update)
+	testData := []byte("Hello, Subscriber!")
+	task.WriteToBuffer(testData)
+
+	// Should receive update
+	select {
+	case update := <-updates:
+		if string(update.LogChunk) != string(testData) {
+			t.Errorf("Expected LogChunk %v, got %v", string(testData), string(update.LogChunk))
+		}
+		if update.JobID != job.Id {
+			t.Errorf("Expected JobID %v, got %v", job.Id, update.JobID)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Did not receive update from WriteToBuffer")
+	}
+}


### PR DESCRIPTION
- Successful Force Kill = STOPPED: When a process is successfully force-killed ("forced" method), it's now correctly marked as STOPPED instead of FAILED
- Longer Graceful Period: Increased timeout from 100ms to 5 seconds, giving processes a reasonable chance to shut down gracefully
Explicit Error Handling: Only actual failures (like inability to send signals) are marked as FAILED